### PR TITLE
Publisher security setting is not being picked up

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Install a verdaccio NPM server (cache & private repo)
 See : https://github.com/verdaccio/verdaccio/'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.1'
+version '1.0.2'
 source_url 'https://github.com/kgrubb/verdaccio-cookbook'
 issues_url 'https://github.com/kgrubb/verdaccio-cookbook/issues'
 

--- a/templates/default/config.yaml.erb
+++ b/templates/default/config.yaml.erb
@@ -41,7 +41,7 @@ packages:
     <% if filter['publish'] == '@admins' %>
     allow_publish: admin <%= @admins.join(' ') %>
     <% else %>
-    allow_publish: admin <%= filter['access'].join(' ') %>
+    allow_publish: admin <%= filter['publish'].join(' ') %>
     <% end %>
   <% else %>
     allow_publish: admin


### PR DESCRIPTION
Hi Keli, found a bug in the filters where the publisher is not being properly populated, as it's picking data from access var instead. This PR fixes it ;) Thanks!